### PR TITLE
Save LDAP admin password for debops.secret

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -94,6 +94,10 @@ slapd_basedn_admin_password: '{{ slapd_basedn_admin_basepw + ".password" }}'
 # Hash of BaseDN administrator password
 slapd_basedn_admin_hash: '{{ slapd_basedn_admin_basepw + ".hash" }}'
 
+# Location of the Ansible password file for LDAP admin access
+# (see 'debops.secret' role for more details)
+slapd_basedn_admin_ansible_password: '{{ secret_ldap_admin_password }}'
+
 
 # ---- ldapscripts configuration ----
 

--- a/tasks/password_basedn_admin.yml
+++ b/tasks/password_basedn_admin.yml
@@ -43,3 +43,16 @@
     olcRootPW: '{{ slapd_register_basedn_admin_password.stdout | default(slapd_register_basedn_admin_hash) }}'
   no_log: True
 
+- name: Create path to LDAP password file in secrets
+  set_fact:
+    slapd_register_basedn_admin_ansible_phony_password: '{{ lookup("password", slapd_basedn_admin_ansible_password) }}'
+  when: slapd_basedn_admin_ansible_password is defined and slapd_basedn_admin_ansible_password
+
+- name: Save BaseDN administrator password for Ansible
+  copy:
+    src: '{{ slapd_basedn_admin_password }}'
+    dest: '{{ slapd_basedn_admin_ansible_password }}'
+  sudo: False
+  delegate_to: 'localhost'
+  when: slapd_basedn_admin_ansible_password is defined and slapd_basedn_admin_ansible_password
+


### PR DESCRIPTION
This password is used by other Ansible roles to access LDAP admin
account, used by 'ldap_attr' and 'ldap_entry' modules.