### PR TITLE
Don't allow users to write their own attributes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,5 +6,10 @@ v0.1.0
 
 *Unreleased*
 
+- Change the default ``olcAccess`` rules to not allow users to modify all of
+  their own attributes by default. Fixes `Debian Bug #761406`_. [drybjed]
+
+.. _Debian Bug #761406: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=761406
+
 - First release, add CHANGES.rst [drybjed]
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -197,7 +197,7 @@ slapd_ldap_access_control_list_default:
         by tls_ssf=128 ssf=128 * read'
 
   - '{3}to *
-        by tls_ssf=128 ssf=128 self write
+        by tls_ssf=128 ssf=128 self read
         by tls_ssf=128 ssf=128 dn="{{ slapd_basedn_admin }}" write
         by * none'
 


### PR DESCRIPTION
By default olcAccess will prevent LDAP entry owners write access to
all of their entry attributes to fix Debian Bug #761406.

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=761406