### PR TITLE
Share cn=admin account between slapd hosts

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,3 +31,14 @@ v0.1.0
   dynamically by a lookup template during Ansible run. Old lists are detected
   and should work as intended. [drybjed]
 
+- Change ``cn=admin,dc=...`` account path in ``secret/`` directory so that it
+  is shared among all ``slapd`` hosts in the cluster. This will stop the
+  password from being updated over and over in ``secret/ldap/`` directory (for
+  other roles), however a tradeoff will be an error at initial creation of the
+  password if multiple ``slapd`` hosts are run at once due to an Ansible
+  ``lookup()`` conflict; this can be avoided by creating the initial
+  configuration on one of the servers instead of all of them.
+
+  This commit might change the LDAP administrator password, you need to update
+  it elsewhere after the change. [drybjed]
+

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -96,7 +96,7 @@ slapd_config_admin_hash: '{{ slapd_config_admin_basepw + ".hash" }}'
 slapd_basedn_admin: '{{ "cn=admin," + slapd_basedn }}'
 
 # Base path to BaseDN administrator password
-slapd_basedn_admin_basepw: '{{ secret + "/credentials/" + ansible_fqdn + "/slapd/" + slapd_basedn + "/" + slapd_basedn_admin }}'
+slapd_basedn_admin_basepw: '{{ secret + "/slapd/credentials/" + slapd_basedn + "/" + slapd_basedn_admin }}'
 
 # Plaintext password of BaseDN administrator
 slapd_basedn_admin_password: '{{ slapd_basedn_admin_basepw + ".password" }}'


### PR DESCRIPTION
Change 'cn=admin,dc=...' account path in 'secret/' directory so that it
is shared among all 'slapd' hosts in the cluster. This will stop the
password from being updated over and over in 'secret/ldap/' directory
(for other roles), however a tradeoff will be an error at initial
creation of the password if multiple 'slapd' hosts are run at once due
to an Ansible 'lookup()' conflict; this can be avoided by creating the
initial configuration on one of the servers instead of all of them.

This commit might change the LDAP administrator password, you need to
update it elsewhere after the change.