### PR TITLE
Allow to define empty access control list

### DIFF
--- a/templates/lookup/slapd_ldap_access_control_list.j2
+++ b/templates/lookup/slapd_ldap_access_control_list.j2
@@ -1,5 +1,5 @@
 {% set disable_counter = False %}
-{% if slapd_ldap_access_control_list[0] | search("^{") %}
+{% if slapd_ldap_access_control_list|d([]) and slapd_ldap_access_control_list[0] | search("^{") %}
 {% set disable_counter = True %}
 {% endif %}
 {% for item in slapd_ldap_access_control_list %}


### PR DESCRIPTION
Just a small fix for an issue that I found when testing stuff